### PR TITLE
feat!: no default ctx is breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,16 @@ const pk = new Uint8Array(CryptoPublicKeyBytes);  // 2592 bytes
 const sk = new Uint8Array(CryptoSecretKeyBytes);  // 4896 bytes
 cryptoSignKeypair(null, pk, sk);
 
-// Sign a message (uses default "ZOND" context for "QRL v2.0" applications)
+// Sign a message with context for domain separation (FIPS 204)
 const message = new TextEncoder().encode('The sleeper must awaken');
-const signedMessage = cryptoSign(message, sk, false);
+const ctx = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]);  // "ZOND"
+const signedMessage = cryptoSign(message, sk, false, ctx);
 
-// Verify and extract
-const extracted = cryptoSignOpen(signedMessage, pk);
+// Verify and extract (context must match)
+const extracted = cryptoSignOpen(signedMessage, pk, ctx);
 if (extracted === undefined) {
   throw new Error('Invalid signature');
 }
-
-// With custom context (FIPS 204 feature)
-const customContext = new TextEncoder().encode('my-app-v1');
-const signedWithCtx = cryptoSign(message, sk, false, customContext);
-const extractedWithCtx = cryptoSignOpen(signedWithCtx, pk, customContext);
 ```
 
 > [!NOTE]
@@ -241,15 +237,16 @@ This library is browser-compatible. It uses native `Uint8Array` throughout (no N
     cryptoSignOpen,
     CryptoPublicKeyBytes,
     CryptoSecretKeyBytes,
-  } from 'https://cdn.jsdelivr.net/npm/@theqrl/mldsa87@1.1.1/dist/mjs/mldsa87.js';
+  } from 'https://cdn.jsdelivr.net/npm/@theqrl/mldsa87@2.0.0/dist/mjs/mldsa87.js';
 
   const pk = new Uint8Array(CryptoPublicKeyBytes);
   const sk = new Uint8Array(CryptoSecretKeyBytes);
   cryptoSignKeypair(null, pk, sk);
 
   const message = new TextEncoder().encode('Hello from browser!');
-  const signed = cryptoSign(message, sk, false);
-  const verified = cryptoSignOpen(signed, pk);
+  const ctx = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]);  // "ZOND"
+  const signed = cryptoSign(message, sk, false, ctx);
+  const verified = cryptoSignOpen(signed, pk, ctx);
   console.log('Verified:', verified !== undefined);
 </script>
 ```

--- a/packages/dilithium5/dist/cjs/dilithium5.js
+++ b/packages/dilithium5/dist/cjs/dilithium5.js
@@ -551,7 +551,7 @@ function cAddQ(a) {
 
 function ntt(a) {
   let k = 0;
-  let j = 0;
+  let j;
 
   for (let len = 128; len > 0; len >>= 1) {
     for (let start = 0; start < N; start = j + len) {
@@ -567,7 +567,7 @@ function ntt(a) {
 
 function invNTTToMont(a) {
   const f = 41978n; // mont^2/256
-  let j = 0;
+  let j;
   let k = 256;
 
   for (let len = 1; len < N; len <<= 1) {
@@ -1557,9 +1557,9 @@ function cryptoSignKeypair(passedSeed, pk, sk) {
     }
   } catch (e) {
     if (e instanceof TypeError) {
-      throw new Error(`pk/sk cannot be null`);
+      throw new Error(`pk/sk cannot be null`, { cause: e });
     } else {
-      throw new Error(`${e.message}`);
+      throw new Error(`${e.message}`, { cause: e });
     }
   }
 

--- a/packages/dilithium5/dist/mjs/dilithium5.js
+++ b/packages/dilithium5/dist/mjs/dilithium5.js
@@ -172,7 +172,7 @@ function cAddQ(a) {
 
 function ntt(a) {
   let k = 0;
-  let j = 0;
+  let j;
 
   for (let len = 128; len > 0; len >>= 1) {
     for (let start = 0; start < N; start = j + len) {
@@ -188,7 +188,7 @@ function ntt(a) {
 
 function invNTTToMont(a) {
   const f = 41978n; // mont^2/256
-  let j = 0;
+  let j;
   let k = 256;
 
   for (let len = 1; len < N; len <<= 1) {
@@ -1178,9 +1178,9 @@ function cryptoSignKeypair(passedSeed, pk, sk) {
     }
   } catch (e) {
     if (e instanceof TypeError) {
-      throw new Error(`pk/sk cannot be null`);
+      throw new Error(`pk/sk cannot be null`, { cause: e });
     } else {
-      throw new Error(`${e.message}`);
+      throw new Error(`${e.message}`, { cause: e });
     }
   }
 

--- a/packages/mldsa87/README.md
+++ b/packages/mldsa87/README.md
@@ -26,12 +26,13 @@ const pk = new Uint8Array(CryptoPublicKeyBytes);  // 2592 bytes
 const sk = new Uint8Array(CryptoSecretKeyBytes);  // 4896 bytes
 cryptoSignKeypair(null, pk, sk);  // null = random seed
 
-// Sign a message (uses default "ZOND" context)
+// Sign a message
 const message = new TextEncoder().encode('Hello, quantum world!');
-const signedMessage = cryptoSign(message, sk, false);  // false = deterministic
+const ctx = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]);  // "ZOND"
+const signedMessage = cryptoSign(message, sk, false, ctx);  // false = deterministic
 
-// Verify and extract
-const extracted = cryptoSignOpen(signedMessage, pk);
+// Verify and extract (context must match)
+const extracted = cryptoSignOpen(signedMessage, pk, ctx);
 if (extracted === undefined) {
   throw new Error('Invalid signature');
 }
@@ -40,20 +41,21 @@ console.log(new TextDecoder().decode(extracted));  // "Hello, quantum world!"
 
 ## Context Parameter
 
-ML-DSA-87 supports a context parameter for domain separation (FIPS 204 feature). This allows the same keypair to be used safely across different applications.
+ML-DSA-87 requires a context parameter for domain separation (FIPS 204 feature). This allows the same keypair to be used safely across different applications.
 
 ```javascript
-// With custom context
+// With application-specific context
 const ctx = new TextEncoder().encode('my-app-v1');
 const signed = cryptoSign(message, sk, false, ctx);
 const extracted = cryptoSignOpen(signed, pk, ctx);
 
 // Context must match for verification
-cryptoSignOpen(signed, pk);  // undefined - wrong context (default "ZOND")
-cryptoSignOpen(signed, pk, ctx);  // message - correct context
+const wrongCtx = new Uint8Array(0);
+cryptoSignOpen(signed, pk, wrongCtx);  // undefined - wrong context
+cryptoSignOpen(signed, pk, ctx);       // message - correct context
 ```
 
-The default context is `"ZOND"` (for QRL Zond network compatibility). Context can be 0-255 bytes.
+Context is a required `Uint8Array` and can be 0-255 bytes. Use an empty `Uint8Array(0)` if no domain separation is needed.
 
 ## API
 
@@ -77,26 +79,26 @@ Generate a keypair from a seed.
 - `sk`: `Uint8Array(4896)` - output buffer for secret key
 - Returns: The seed used (useful when `seed` is `null`)
 
-#### `cryptoSign(message, sk, randomized, context?)`
+#### `cryptoSign(message, sk, randomized, context)`
 
 Sign a message (combined mode: returns signature || message).
 
 - `message`: `Uint8Array` or `string` - message bytes; if `string`, it must be hex only (optional `0x`, even length). Plain-text strings are not accepted.
 - `sk`: `Uint8Array(4896)` - secret key
 - `randomized`: `boolean` - `true` for hedged signing, `false` for deterministic
-- `context`: `Uint8Array` (optional) - context string, 0-255 bytes. Default: `"ZOND"`
+- `context`: `Uint8Array` - context string for domain separation, 0-255 bytes
 - Returns: `Uint8Array` containing signature + message
 
-#### `cryptoSignOpen(signedMessage, pk, context?)`
+#### `cryptoSignOpen(signedMessage, pk, context)`
 
 Verify and extract message from signed message.
 
 - `signedMessage`: `Uint8Array` - output from `cryptoSign()`
 - `pk`: `Uint8Array(2592)` - public key
-- `context`: `Uint8Array` (optional) - must match signing context
+- `context`: `Uint8Array` - must match signing context
 - Returns: Original message if valid, `undefined` if verification fails
 
-#### `cryptoSignSignature(sig, message, sk, randomized, context?)`
+#### `cryptoSignSignature(sig, message, sk, randomized, context)`
 
 Create a detached signature.
 
@@ -104,17 +106,17 @@ Create a detached signature.
 - `message`: `Uint8Array` or `string` - message bytes; if `string`, it must be hex only (optional `0x`, even length). Plain-text strings are not accepted.
 - `sk`: `Uint8Array(4896)` - secret key
 - `randomized`: `boolean` - `true` for hedged, `false` for deterministic
-- `context`: `Uint8Array` (optional) - context string, 0-255 bytes
+- `context`: `Uint8Array` - context string for domain separation, 0-255 bytes
 - Returns: `0` on success
 
-#### `cryptoSignVerify(sig, message, pk, context?)`
+#### `cryptoSignVerify(sig, message, pk, context)`
 
 Verify a detached signature.
 
 - `sig`: `Uint8Array(4627)` - signature to verify
 - `message`: `Uint8Array` or `string` - original message bytes; if `string`, it must be hex only (optional `0x`, even length). Plain-text strings are not accepted.
 - `pk`: `Uint8Array(2592)` - public key
-- `context`: `Uint8Array` (optional) - must match signing context
+- `context`: `Uint8Array` - must match signing context
 - Returns: `true` if valid, `false` otherwise
 
 **Note:** To sign or verify plain text, convert it to bytes (e.g., `new TextEncoder().encode('Hello')`). String inputs are interpreted as hex only.

--- a/packages/mldsa87/dist/cjs/mldsa87.js
+++ b/packages/mldsa87/dist/cjs/mldsa87.js
@@ -1646,9 +1646,8 @@ function cryptoSignKeypair(passedSeed, pk, sk) {
  *
  * @example
  * const sig = new Uint8Array(CryptoBytes);
- * cryptoSignSignature(sig, message, sk, false);
- * // Or with custom context:
- * cryptoSignSignature(sig, message, sk, false, new Uint8Array([0x01, 0x02]));
+ * const ctx = new Uint8Array([0x01, 0x02]);
+ * cryptoSignSignature(sig, message, sk, false, ctx);
  */
 function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
   if (!sig || sig.length < CryptoBytes) {
@@ -1792,6 +1791,9 @@ function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
  * // signedMsg contains: signature (4627 bytes) || message
  */
 function cryptoSign(msg, sk, randomizedSigning, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   const msgBytes = messageToBytes(msg);
 
   const sm = new Uint8Array(CryptoBytes + msgBytes.length);
@@ -1928,6 +1930,9 @@ function cryptoSignVerify(sig, m, pk, ctx) {
  * }
  */
 function cryptoSignOpen(sm, pk, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   if (sm.length < CryptoBytes) {
     return undefined;
   }

--- a/packages/mldsa87/dist/mjs/mldsa87.js
+++ b/packages/mldsa87/dist/mjs/mldsa87.js
@@ -1267,9 +1267,8 @@ function cryptoSignKeypair(passedSeed, pk, sk) {
  *
  * @example
  * const sig = new Uint8Array(CryptoBytes);
- * cryptoSignSignature(sig, message, sk, false);
- * // Or with custom context:
- * cryptoSignSignature(sig, message, sk, false, new Uint8Array([0x01, 0x02]));
+ * const ctx = new Uint8Array([0x01, 0x02]);
+ * cryptoSignSignature(sig, message, sk, false, ctx);
  */
 function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
   if (!sig || sig.length < CryptoBytes) {
@@ -1413,6 +1412,9 @@ function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
  * // signedMsg contains: signature (4627 bytes) || message
  */
 function cryptoSign(msg, sk, randomizedSigning, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   const msgBytes = messageToBytes(msg);
 
   const sm = new Uint8Array(CryptoBytes + msgBytes.length);
@@ -1549,6 +1551,9 @@ function cryptoSignVerify(sig, m, pk, ctx) {
  * }
  */
 function cryptoSignOpen(sm, pk, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   if (sm.length < CryptoBytes) {
     return undefined;
   }

--- a/packages/mldsa87/src/sign.js
+++ b/packages/mldsa87/src/sign.js
@@ -212,9 +212,8 @@ export function cryptoSignKeypair(passedSeed, pk, sk) {
  *
  * @example
  * const sig = new Uint8Array(CryptoBytes);
- * cryptoSignSignature(sig, message, sk, false);
- * // Or with custom context:
- * cryptoSignSignature(sig, message, sk, false, new Uint8Array([0x01, 0x02]));
+ * const ctx = new Uint8Array([0x01, 0x02]);
+ * cryptoSignSignature(sig, message, sk, false, ctx);
  */
 export function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
   if (!sig || sig.length < CryptoBytes) {
@@ -358,6 +357,9 @@ export function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
  * // signedMsg contains: signature (4627 bytes) || message
  */
 export function cryptoSign(msg, sk, randomizedSigning, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   const msgBytes = messageToBytes(msg);
 
   const sm = new Uint8Array(CryptoBytes + msgBytes.length);
@@ -494,6 +496,9 @@ export function cryptoSignVerify(sig, m, pk, ctx) {
  * }
  */
 export function cryptoSignOpen(sm, pk, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   if (sm.length < CryptoBytes) {
     return undefined;
   }

--- a/packages/mldsa87/test/coverage.test.js
+++ b/packages/mldsa87/test/coverage.test.js
@@ -198,6 +198,12 @@ describe('coverage: signing and verification branches', () => {
     expect(cryptoSignVerify(sig, new Uint8Array([1, 2, 3]), pk, new Uint8Array(0))).to.equal(false);
   });
 
+  it('should throw without ctx in cryptoSignSignature', () => {
+    const sk = new Uint8Array(CryptoSecretKeyBytes);
+    const sig = new Uint8Array(CryptoBytes);
+    expect(() => cryptoSignSignature(sig, new Uint8Array([1]), sk, false)).to.throw('ctx is required');
+  });
+
   it('should reject overlong contexts', () => {
     const pk = new Uint8Array(CryptoPublicKeyBytes);
     const sk = new Uint8Array(CryptoSecretKeyBytes);

--- a/packages/mldsa87/test/sign.test.js
+++ b/packages/mldsa87/test/sign.test.js
@@ -150,7 +150,7 @@ describe('cryptoSignSignature', () => {
     const sig = new Uint8Array(CryptoBytes);
 
     expect(() => {
-      cryptoSignSignature(sig, '0xabc', sk, false, Buffer.from(v0.ctx, 'hex'));
+      cryptoSignSignature(sig, '0xabc', sk, false, v0.ctx);
     }).to.throw('hex string must have an even length');
   });
 
@@ -170,7 +170,7 @@ describe('cryptoSignVerify invalid hex message', () => {
     const sig = Buffer.from(v0.derivedSig, 'hex');
     const pk = Buffer.from(v0.derivedPK, 'hex');
 
-    expect(cryptoSignVerify(sig, 'xyz', pk, Buffer.from(v0.ctx, 'hex'))).to.equal(false);
+    expect(cryptoSignVerify(sig, 'xyz', pk, v0.ctx)).to.equal(false);
   });
 });
 


### PR DESCRIPTION
  packages/mldsa87/src/sign.js

  - Fixed JSDoc example on cryptoSignSignature [removed invalid no-ctx example, now shows a single correct example with ctx]
  - Added early ctx validation to cryptoSign() and cryptoSignOpen() [both now throw TypeError('ctx is required and must be a Uint8Array') at their own entry points instead of letting confusing errors bubble up from inner functions]

  packages/mldsa87/test/sign.test.js

  - Removed Buffer.from(v0.ctx, 'hex') in two tests (lines 153, 173) [replaced with v0.ctx since it's already a Uint8Array]

  packages/mldsa87/test/coverage.test.js

  - Added test for calling cryptoSignSignature directly without ctx [restores 100% code coverage after the early validation in cryptoSign made the inner check otherwise unreachable via that path]

  packages/mldsa87/README.md

  - Quick Start: added ctx parameter to cryptoSign and cryptoSignOpen examples
  - Context Parameter section: changed "supports" to "requires", removed false claim of "ZOND" default, updated examples to show wrong-ctx (not missing-ctx) behavior
  - API signatures: changed context? to context (required) for all four sign/verify functions

  README.md (root)

  - Quick Start: added ctx to cryptoSign/cryptoSignOpen, removed now-redundant "with custom context" secondary example
  - Browser Usage: added ctx to cryptoSign/cryptoSignOpen example
  - CDN version: bumped @theqrl/mldsa87@1.1.1 → @2.0.0 for the upcoming major release